### PR TITLE
fixing error icon in console

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <link rel="icon" href="תוית.PNG" />
+    <link rel="icon" href="label.PNG" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
     <meta

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -8,7 +8,7 @@
       "type": "image/x-icon"
     },
     {
-      "src": "תוית.PNG",
+      "src": "lebel.PNG",
       "type": "image/png",
       "sizes": "192x192"
     },


### PR DESCRIPTION
the error:
Error while trying to use the following icon from the Manifest: https://homedesignstore.netlify.app/%D7%AA%D7%95%D7%99%D7%AA.PNG (Resource size is not correct - typo in the Manifest?)